### PR TITLE
Task 3 - Enable SSM Connectivity and Basic Web Server for EC2 Instances

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -23,3 +23,61 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:d179ef28843fe663fc63169291a211898199009f0d3f63f0a6f65349e77727ec",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.2.4"
+  constraints = ">= 3.0.0"
+  hashes = [
+    "h1:+Ag4hSb4qQjNtAS6gj2+gsGl7v0iB/Bif6zZZU8lXsw=",
+    "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:795c897119ff082133150121d39ff26cb5f89a730a2c8c26f3a9c1abf81a9c43",
+    "zh:7b9c7b16f118fbc2b05a983817b8ce2f86df125857966ad356353baf4bff5c0a",
+    "zh:85e33ab43e0e1726e5f97a874b8e24820b6565ff8076523cc2922ba671492991",
+    "zh:9d32ac3619cfc93eb3c4f423492a8e0f79db05fec58e449dee9b2d5873d5f69f",
+    "zh:9e15c3c9dd8e0d1e3731841d44c34571b6c97f5b95e8296a45318b94e5287a6e",
+    "zh:b4c2ab35d1b7696c30b64bf2c0f3a62329107bd1a9121ce70683dec58af19615",
+    "zh:c43723e8cc65bcdf5e0c92581dcbbdcbdcf18b8d2037406a5f2033b1e22de442",
+    "zh:ceb5495d9c31bfb299d246ab333f08c7fb0d67a4f82681fbf47f2a21c3e11ab5",
+    "zh:e171026b3659305c558d9804062762d168f50ba02b88b231d20ec99578a6233f",
+    "zh:ed0fe2acdb61330b01841fa790be00ec6beaac91d41f311fb8254f74eb6a711f",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/template" {
+  version     = "2.2.0"
+  constraints = ">= 2.0.0"
+  hashes = [
+    "h1:LN84cu+BZpVRvYlCzrbPfCRDaIelSyEx/W9Iwwgbnn4=",
+    "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
+    "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
+    "zh:09ba83c0625b6fe0a954da6fbd0c355ac0b7f07f86c91a2a97849140fea49603",
+    "zh:0e3a6c8e16f17f19010accd0844187d524580d9fdb0731f675ffcf4afba03d16",
+    "zh:45f2c594b6f2f34ea663704cc72048b212fe7d16fb4cfd959365fa997228a776",
+    "zh:77ea3e5a0446784d77114b5e851c970a3dde1e08fa6de38210b8385d7605d451",
+    "zh:8a154388f3708e3df5a69122a23bdfaf760a523788a5081976b3d5616f7d30ae",
+    "zh:992843002f2db5a11e626b3fc23dc0c87ad3729b3b3cff08e32ffb3df97edbde",
+    "zh:ad906f4cebd3ec5e43d5cd6dc8f4c5c9cc3b33d2243c89c5fc18f97f7277b51d",
+    "zh:c979425ddb256511137ecd093e23283234da0154b7fa8b21c2687182d9aea8b2",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "4.1.0"
+  constraints = ">= 3.0.0"
+  hashes = [
+    "h1:y9cHrgcuaZt592In6xQzz1lx7k/B9EeWrAb8K7QqOgU=",
+    "zh:14c35d89307988c835a7f8e26f1b83ce771e5f9b41e407f86a644c0152089ac2",
+    "zh:2fb9fe7a8b5afdbd3e903acb6776ef1be3f2e587fb236a8c60f11a9fa165faa8",
+    "zh:35808142ef850c0c60dd93dc06b95c747720ed2c40c89031781165f0c2baa2fc",
+    "zh:35b5dc95bc75f0b3b9c5ce54d4d7600c1ebc96fbb8dfca174536e8bf103c8cdc",
+    "zh:38aa27c6a6c98f1712aa5cc30011884dc4b128b4073a4a27883374bfa3ec9fac",
+    "zh:51fb247e3a2e88f0047cb97bb9df7c228254a3b3021c5534e4563b4007e6f882",
+    "zh:62b981ce491e38d892ba6364d1d0cdaadcee37cc218590e07b310b1dfa34be2d",
+    "zh:bc8e47efc611924a79f947ce072a9ad698f311d4a60d0b4dfff6758c912b7298",
+    "zh:c149508bd131765d1bc085c75a870abb314ff5a6d7f5ac1035a8892d686b6297",
+    "zh:d38d40783503d278b63858978d40e07ac48123a2925e1a6b47e62179c046f87a",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fb07f708e3316615f6d218cec198504984c0ce7000b9f1eebff7516e384f4b54",
+  ]
+}

--- a/main.tf
+++ b/main.tf
@@ -73,9 +73,8 @@ resource "aws_instance" "web-server" {
 
   ami                  = "ami-0953476d60561c955"
   instance_type        = "t2.micro"
-  subnet_id            = module.vpc.private_subnets[0]
-  availability_zone    = "us-east-1a"
-  security_groups      = [aws_security_group.ssm_sg.id]
+  subnet_id            = module.vpc.private_subnets[count.index]
+  security_groups      = [aws_security_group.ec2_ssm_sg.id]
   iam_instance_profile = aws_iam_instance_profile.ssm_instance_profile.name
   user_data            = <<-EOF
               #!/bin/bash
@@ -93,34 +92,67 @@ resource "aws_instance" "web-server" {
 }
 
 #security groups
-resource "aws_security_group" "ssm_sg" {
+#ec2 sg
+resource "aws_security_group" "ec2_ssm_sg" {
   name        = "allow_ssm"
-  description = "Allow connection to SSM"
+  description = "Security group for EC2 instances allowing outbound SSM communication."
   vpc_id      = module.vpc.vpc_id
 
   tags = {
-    Name = "ssm-sg"
+    Name = "EC2-SSM-Instance-SG"
   }
 }
 
-resource "aws_vpc_security_group_ingress_rule" "allow_https" {
-  security_group_id = aws_security_group.ssm_sg.id
-  cidr_ipv4         = "10.0.1.0/24"
-  from_port         = 443
-  ip_protocol       = "tcp"
-  to_port           = 443
+resource "aws_vpc_security_group_egress_rule" "allow_endpoints_https_out" {
+  security_group_id            = aws_security_group.ec2_ssm_sg.id
+  from_port                    = 443
+  to_port                      = 443
+  ip_protocol                  = "tcp"
+  referenced_security_group_id = aws_security_group.ssm_vpc_endpoint_sg.id
+  description                  = "Allow outbound HTTPS to SSM endpoints"
 }
 
 resource "aws_vpc_security_group_ingress_rule" "allow_http" {
-  security_group_id            = aws_security_group.ssm_sg.id
-  referenced_security_group_id = aws_security_group.ssm_sg.id
-  ip_protocol                  = "-1"
+  security_group_id = aws_security_group.ec2_ssm_sg.id
+  from_port         = 80
+  to_port           = 80
+  ip_protocol       = "tcp"
+  cidr_ipv4         = module.vpc.vpc_cidr_block
+  description       = "Allows HTTP from within VPC for web server"
 }
 
-resource "aws_vpc_security_group_egress_rule" "allow_all_traffic_ipv4" {
-  security_group_id = aws_security_group.ssm_sg.id
+resource "aws_vpc_security_group_ingress_rule" "allow_ec2sg_in" {
+  security_group_id            = aws_security_group.ec2_ssm_sg.id
+  referenced_security_group_id = aws_security_group.ec2_ssm_sg.id
+  ip_protocol                  = "-1"
+  description                  = "Allow all traffic from within itself"
+}
+
+resource "aws_vpc_security_group_egress_rule" "allow_all_out" {
+  security_group_id = aws_security_group.ec2_ssm_sg.id
   cidr_ipv4         = "0.0.0.0/0"
   ip_protocol       = "-1"
+  description       = "Allow all egress traffic"
+}
+
+#vpc sg
+resource "aws_security_group" "ssm_vpc_endpoint_sg" {
+  name        = "ssm-vpc-endpoint-sg"
+  description = "Security group for SSM VPC Endpoints"
+  vpc_id      = module.vpc.vpc_id
+
+  tags = {
+    Name = "SSM-VPC-Endpoint-SG"
+  }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "allow_https_ec2_in" {
+  security_group_id            = aws_security_group.ssm_vpc_endpoint_sg.id
+  from_port                    = 443
+  to_port                      = 443
+  ip_protocol                  = "tcp"
+  referenced_security_group_id = aws_security_group.ec2_ssm_sg.id
+  description                  = "Allow HTTPS from EC2 instances for SSM"
 }
 
 #SSM Endpoints
@@ -129,7 +161,7 @@ resource "aws_vpc_endpoint" "ssm_endpoint" {
   subnet_ids          = module.vpc.private_subnets
   service_name        = "com.amazonaws.us-east-1.ssm"
   vpc_endpoint_type   = "Interface"
-  security_group_ids  = [aws_security_group.ssm_sg.id]
+  security_group_ids  = [aws_security_group.ssm_vpc_endpoint_sg.id]
   private_dns_enabled = true
 
   tags = {
@@ -142,7 +174,7 @@ resource "aws_vpc_endpoint" "ssmmessages_endpoint" {
   subnet_ids          = module.vpc.private_subnets
   service_name        = "com.amazonaws.us-east-1.ssmmessages"
   vpc_endpoint_type   = "Interface"
-  security_group_ids  = [aws_security_group.ssm_sg.id]
+  security_group_ids  = [aws_security_group.ssm_vpc_endpoint_sg.id]
   private_dns_enabled = true
 
   tags = {
@@ -155,7 +187,7 @@ resource "aws_vpc_endpoint" "ec2messages_endpoint" {
   subnet_ids          = module.vpc.private_subnets
   service_name        = "com.amazonaws.us-east-1.ec2messages"
   vpc_endpoint_type   = "Interface"
-  security_group_ids  = [aws_security_group.ssm_sg.id]
+  security_group_ids  = [aws_security_group.ssm_vpc_endpoint_sg.id]
   private_dns_enabled = true
 
   tags = {

--- a/main.tf
+++ b/main.tf
@@ -1,72 +1,164 @@
+#Providers
 terraform {
-    required_providers {
-        aws = {
-            source = "hashicorp/aws"
-            version = "~> 5.0"
-        }
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
     }
+  }
 }
 
 provider "aws" {
-    region = "us-east-1"
-    profile = "terraform"
+  region  = "us-east-1"
+  profile = "terraform"
 }
 
+#Network
 module "vpc" {
   source = "terraform-aws-modules/vpc/aws"
 
   name = "main"
   cidr = "10.0.0.0/16"
 
-  azs             = ["us-east-1a"]
-  private_subnets = ["10.0.1.0/24"]
-  public_subnets  = ["10.0.101.0/24"]
+  azs             = ["us-east-1a", "us-east-1b"]
+  private_subnets = ["10.0.1.0/24", "10.0.2.0/24"]
+  public_subnets  = ["10.0.101.0/24", "10.0.102.0/24"]
+
+  enable_nat_gateway = true
+  single_nat_gateway = true
 
   tags = {
-    Terraform = "true"
+    Terraform   = "true"
     Environment = "dev"
   }
 }
 
-resource "aws_instance" "private-instance" {
-  count             = 2
 
-  ami               = "ami-0953476d60561c955"
-  instance_type     = "t2.micro"
 
-  subnet_id         = module.vpc.private_subnets[0]
-  availability_zone = "us-east-1a"
-  security_groups = [aws_security_group.allow_ssh_sg.id]
+#Role
+resource "aws_iam_role" "ssm_instance_role" {
+  name = "ssm-instance-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+      },
+    ]
+  })
 
   tags = {
-    Name = "private-instance-${count.index}"
+    Name = "SSM-Enabled-EC2-Role"
   }
 }
 
-resource "aws_security_group" "allow_ssh_sg" {
-  name = "allow_ssh_sg"
-  description = "Allow SSH from anywhere"
-  vpc_id = module.vpc.vpc_id
+resource "aws_iam_role_policy_attachment" "ssm_policy_attach" {
+  role       = aws_iam_role.ssm_instance_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_instance_profile" "ssm_instance_profile" {
+  name = "ssm-instance-profile"
+  role = aws_iam_role.ssm_instance_role.name
+}
+
+#EC2 Instances
+resource "aws_instance" "web-server" {
+  count = 2
+
+  ami                  = "ami-0953476d60561c955"
+  instance_type        = "t2.micro"
+  subnet_id            = module.vpc.private_subnets[0]
+  availability_zone    = "us-east-1a"
+  security_groups      = [aws_security_group.ssm_sg.id]
+  iam_instance_profile = aws_iam_instance_profile.ssm_instance_profile.name
+  user_data            = <<-EOF
+              #!/bin/bash
+              sudo yum update -y
+              sudo yum install -y httpd
+              sudo systemctl start httpd
+              sudo systemctl enable httpd
+              sudo touch /var/www/html/index.html
+              echo "<h1>Hello World from EPAM's Terraform Course</h1>" > /var/www/html/index.html
+              EOF
 
   tags = {
-    name = "allow_ssh_sg"
+    Name = "web-server-${count.index}"
   }
 }
 
-resource "aws_vpc_security_group_ingress_rule" "allow_ssh_rule" {
-  security_group_id = aws_security_group.allow_ssh_sg.id
-  
-  cidr_ipv4   = "0.0.0.0/0"
-  from_port   = 22
-  ip_protocol = "tcp"
-  to_port     = 22
+#security groups
+resource "aws_security_group" "ssm_sg" {
+  name        = "allow_ssm"
+  description = "Allow connection to SSM"
+  vpc_id      = module.vpc.vpc_id
+
+  tags = {
+    Name = "ssm-sg"
+  }
 }
 
-resource "aws_vpc_security_group_egress_rule" "allow_all_rule" {
-  security_group_id = aws_security_group.allow_ssh_sg.id
-  
-  cidr_ipv4   = "0.0.0.0/0"
-  from_port   = 0
-  ip_protocol = "-1"
-  to_port     = 0
+resource "aws_vpc_security_group_ingress_rule" "allow_https" {
+  security_group_id = aws_security_group.ssm_sg.id
+  cidr_ipv4         = "10.0.1.0/24"
+  from_port         = 443
+  ip_protocol       = "tcp"
+  to_port           = 443
+}
+
+resource "aws_vpc_security_group_ingress_rule" "allow_http" {
+  security_group_id            = aws_security_group.ssm_sg.id
+  referenced_security_group_id = aws_security_group.ssm_sg.id
+  ip_protocol                  = "-1"
+}
+
+resource "aws_vpc_security_group_egress_rule" "allow_all_traffic_ipv4" {
+  security_group_id = aws_security_group.ssm_sg.id
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "-1"
+}
+
+#SSM Endpoints
+resource "aws_vpc_endpoint" "ssm_endpoint" {
+  vpc_id              = module.vpc.vpc_id
+  subnet_ids          = module.vpc.private_subnets
+  service_name        = "com.amazonaws.us-east-1.ssm"
+  vpc_endpoint_type   = "Interface"
+  security_group_ids  = [aws_security_group.ssm_sg.id]
+  private_dns_enabled = true
+
+  tags = {
+    Name = "ssm-endpoint"
+  }
+}
+
+resource "aws_vpc_endpoint" "ssmmessages_endpoint" {
+  vpc_id              = module.vpc.vpc_id
+  subnet_ids          = module.vpc.private_subnets
+  service_name        = "com.amazonaws.us-east-1.ssmmessages"
+  vpc_endpoint_type   = "Interface"
+  security_group_ids  = [aws_security_group.ssm_sg.id]
+  private_dns_enabled = true
+
+  tags = {
+    Name = "ssmmessages-endpoint"
+  }
+}
+
+resource "aws_vpc_endpoint" "ec2messages_endpoint" {
+  vpc_id              = module.vpc.vpc_id
+  subnet_ids          = module.vpc.private_subnets
+  service_name        = "com.amazonaws.us-east-1.ec2messages"
+  vpc_endpoint_type   = "Interface"
+  security_group_ids  = [aws_security_group.ssm_sg.id]
+  private_dns_enabled = true
+
+  tags = {
+    Name = "ec2messages-endpoint"
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -27,3 +27,46 @@ module "vpc" {
     Environment = "dev"
   }
 }
+
+resource "aws_instance" "private-instance" {
+  count             = 2
+
+  ami               = "ami-0953476d60561c955"
+  instance_type     = "t2.micro"
+
+  subnet_id         = module.vpc.private_subnets[0]
+  availability_zone = "us-east-1a"
+  security_groups = [aws_security_group.allow_ssh_sg.id]
+
+  tags = {
+    Name = "private-instance-${count.index}"
+  }
+}
+
+resource "aws_security_group" "allow_ssh_sg" {
+  name = "allow_ssh_sg"
+  description = "Allow SSH from anywhere"
+  vpc_id = module.vpc.vpc_id
+
+  tags = {
+    name = "allow_ssh_sg"
+  }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "allow_ssh_rule" {
+  security_group_id = aws_security_group.allow_ssh_sg.id
+  
+  cidr_ipv4   = "0.0.0.0/0"
+  from_port   = 22
+  ip_protocol = "tcp"
+  to_port     = 22
+}
+
+resource "aws_vpc_security_group_egress_rule" "allow_all_rule" {
+  security_group_id = aws_security_group.allow_ssh_sg.id
+  
+  cidr_ipv4   = "0.0.0.0/0"
+  from_port   = 0
+  ip_protocol = "-1"
+  to_port     = 0
+}


### PR DESCRIPTION
This pull request introduces changes to enhance the manageability and high availability of our EC2 instances, as well as deploy a simple web server on each instance.

- **VPC modifications:**
  - **Availability Zones:** Added "us-east-1b" to ensure HA across multiple AZ.
  - **Subnets:** Introduced new private and public subnets for the secondary AZ.
  - **NAT Gateway:** Deployed a single NAT Gateway to enable private EC2 instances to access external services.

- **New Resoruces:**
  - **Enable SSM Connectivity and Basic Web Server for EC2 Instances** Launched new instances within private subnets.
  - **IAM Role & Instance Profile**: Granting necessary permissions for EC2 Instances to communicate with SSM.
  - **EC2 Security Group**: 
    - Egress on port 443: Allows traffic to VPC SG.
    - Ingress on port 80: Allows HTTP traffic from within the VPC CIDR.
    - Self-referencieng ingress: Permits all traffic within the security group for seamless communication between instances.
    - All egress traffic: Allows instances to initiate outbound connections.
  - **VPC Security Group**
    - Ingress on port 443: Allows traffic from EC2 SG.
  - **VPC Endpoints:** Established private endpoints for SSM, SSM Messages, and EC2 Messages. These endpoints secure communication with SSM services, keeping traffic within the AWS network and improving performance.